### PR TITLE
Public ticker API with mapper

### DIFF
--- a/src/Managers/BxAPIManager/public/index.js
+++ b/src/Managers/BxAPIManager/public/index.js
@@ -5,6 +5,7 @@ const ticker = (completion) => {
     fetch(BxAPIManager.hostname + BxAPIManager.endPoint.public.ticker)
     .then((response) => response.json())
     .then((responseJSON) => {
+        completion(responseJSON)
         return tickerMapper(responseJSON)
     });
 }


### PR DESCRIPTION
I created api request with react fetch and map it for nice to use. 

before it was 

<img src="https://i.imgur.com/HGWqP1C.png">

it's use pair number as key of object which really hard to use. 

so I map it into array of pairs.

close #15